### PR TITLE
Add Bookings#passenger_by_seat_no view

### DIFF
--- a/db/migrate/20170517112352_create_bookings_now_function.rb
+++ b/db/migrate/20170517112352_create_bookings_now_function.rb
@@ -1,0 +1,14 @@
+ROM::SQL.migration do
+  up do
+    run <<-SQL
+      CREATE FUNCTION bookings_now() RETURNS timestamp with time zone
+        LANGUAGE sql IMMUTABLE COST 0.00999999978
+        AS $$SELECT '2016-10-13 17:00:00'::TIMESTAMP
+        AT TIME ZONE 'Europe/Moscow';$$
+    SQL
+  end
+
+  down do
+    run 'DROP FUNCTION bookings_now()'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -45,6 +45,16 @@ COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 SET search_path = bookings, pg_catalog;
 
 --
+-- Name: bookings_now(); Type: FUNCTION; Schema: bookings; Owner: -
+--
+
+CREATE FUNCTION bookings_now() RETURNS timestamp with time zone
+    LANGUAGE sql IMMUTABLE COST 0.00999999978
+    AS $$SELECT '2016-10-13 17:00:00'::TIMESTAMP
+        AT TIME ZONE 'Europe/Moscow';$$;
+
+
+--
 -- Name: now(); Type: FUNCTION; Schema: bookings; Owner: -
 --
 

--- a/lib/persistence/relations/bookings.rb
+++ b/lib/persistence/relations/bookings.rb
@@ -10,6 +10,35 @@ module Persistence
 
         associations do
           has_many :tickets, foreign_key: :book_ref
+          has_many :boarding_passes
+          has_many :ticket_flights
+          has_many :flights
+        end
+      end
+
+      view(:passenger_by_seat_no) do
+        schema do
+          new([relations[:tickets][:passenger_name].qualified,
+               relations[:bookings][:book_date].qualified])
+        end
+
+        relation do |departure_airport, arrival_airport, seat_no, ago|
+          bookings
+            .order(nil)
+            .join(:tickets, book_ref: :book_ref)
+            .join(:boarding_passes, ticket_no: :ticket_no)
+            .join(:flights, flight_id: :flight_id)
+            .where(flights[:departure_airport].qualified => departure_airport)
+            .where(flights[:arrival_airport].qualified => arrival_airport)
+            .where(boarding_passes[:seat_no].qualified => seat_no)
+            .where do
+              date::cast(flights[:scheduled_departure], :date).is(
+                date::cast(
+                  time::bookings_now() - any::cast("#{ago} days", :interval),
+                  :date
+                )
+              )
+            end
         end
       end
     end

--- a/spec/lib/persistence/relations/bookings_spec.rb
+++ b/spec/lib/persistence/relations/bookings_spec.rb
@@ -1,0 +1,30 @@
+require 'db_helper'
+
+RSpec.describe Persistence::Relations::Bookings do
+  let(:bookings) do
+    rom.relations[:bookings]
+  end
+
+  it 'passenger_by_seat_no' do
+    query = bookings.passenger_by_seat_no('SVO', 'OVB', '1A', 2)
+
+    expected = <<~SQL.split("\n").map(&:strip).join(' ')
+      SELECT "tickets"."passenger_name",
+             "bookings"."book_date"
+        FROM "bookings"
+              INNER JOIN "tickets"
+                      ON ("tickets"."book_ref" = "bookings"."book_ref")
+              INNER JOIN "boarding_passes"
+                      ON ("boarding_passes"."ticket_no" = "tickets"."ticket_no")
+              INNER JOIN "flights"
+                      ON ("flights"."flight_id" = "boarding_passes"."flight_id")
+       WHERE (("flights"."departure_airport" = 'SVO')
+         AND ("flights"."arrival_airport" = 'OVB')
+         AND ("boarding_passes"."seat_no" = '1A')
+         AND (CAST("flights"."scheduled_departure" AS date) =
+              CAST((BOOKINGS_NOW() - CAST('2 days' AS interval)) AS date)))
+    SQL
+
+    expect(query.dataset.sql).to eq expected
+  end
+end


### PR DESCRIPTION
We have the following DB schema (defined in [db/structure.sql](../tree/master/db/structure.sql) and  [lib/persistence/relations](../tree/master/lib/persistence/relations))

![](https://postgrespro.ru/media/2017/04/06/scheme1920x1220.png)

<img width="702" alt="pgpro_sql1" src="https://cloud.githubusercontent.com/assets/6506296/25507516/2c34009e-2bb5-11e7-8dbb-204943113079.png">

# Issues
- Currently we have a `now()` function defined in `bookings` schema and called as `bookings.now()`. But we couldn't call it from our _View DSL_ because it doesn't support custom schemas. So, we define a new function with prefix - `bookings_now()` as workaround and use it.